### PR TITLE
Small Windows fixes

### DIFF
--- a/bin/genn-buildmodel.bat
+++ b/bin/genn-buildmodel.bat
@@ -58,37 +58,39 @@ for /f %%I in ("%-i%") do set "-i=%%~fI"
 for /f %%I in ("%MODEL%") do set "MACROS=/p:ModelFile=%%~fI /p:GeneratePath=%-o% /p:BuildModelInclude=%-i%"
 
 if defined -d (
-	set "BACKEND_MACROS= /p:Configuration=Debug"
-	if defined -c (
-		set "BACKEND_PROJECT=single_threaded_cpu_backend"
-		set "MACROS=%MACROS% /p:Configuration=Debug"
-		set GENERATOR=.\generator_Debug.exe
-	)
-	if defined -l (
-		set "BACKEND_PROJECT=opencl_backend"
-		set "MACROS=%MACROS% /p:Configuration=Debug_OpenCL"
-		set GENERATOR=.\generator_Debug_OpenCL.exe
-	) else (
-		set "BACKEND_PROJECT=cuda_backend"
-		set "MACROS=%MACROS% /p:Configuration=Debug_CUDA"
-		set GENERATOR=.\generator_Debug_CUDA.exe
-	)    
+    set "BACKEND_MACROS= /p:Configuration=Debug"
+    if defined -c (
+        set "BACKEND_PROJECT=single_threaded_cpu_backend"
+        set "MACROS=%MACROS% /p:Configuration=Debug"
+        set GENERATOR=.\generator_Debug.exe
+    ) else (
+        if defined -l (
+            set "BACKEND_PROJECT=opencl_backend"
+            set "MACROS=%MACROS% /p:Configuration=Debug_OpenCL"
+            set GENERATOR=.\generator_Debug_OpenCL.exe
+        ) else (
+            set "BACKEND_PROJECT=cuda_backend"
+            set "MACROS=%MACROS% /p:Configuration=Debug_CUDA"
+            set GENERATOR=.\generator_Debug_CUDA.exe
+        )
+    )
 ) else (
-	set "BACKEND_MACROS= /p:Configuration=Release"
-	if defined -c (
-		set "BACKEND_PROJECT=single_threaded_cpu_backend"
-		set "MACROS=%MACROS% /p:Configuration=Release"
-		set GENERATOR=.\generator_Release.exe
-	) 
-	if defined -l (
-		set "BACKEND_PROJECT=opencl_backend"
-		set "MACROS=%MACROS% /p:Configuration=Release_OpenCL"
-		set GENERATOR=.\generator_Release_OpenCL.exe
-	) else (
-		set "BACKEND_PROJECT=cuda_backend"
-		set "MACROS=%MACROS% /p:Configuration=Release_CUDA"
-		set GENERATOR=.\generator_Release_CUDA.exe
-	)
+    set "BACKEND_MACROS= /p:Configuration=Release"
+    if defined -c (
+        set "BACKEND_PROJECT=single_threaded_cpu_backend"
+        set "MACROS=%MACROS% /p:Configuration=Release"
+        set GENERATOR=.\generator_Release.exe
+    ) else ( 
+        if defined -l (
+            set "BACKEND_PROJECT=opencl_backend"
+            set "MACROS=%MACROS% /p:Configuration=Release_OpenCL"
+            set GENERATOR=.\generator_Release_OpenCL.exe
+        ) else (
+            set "BACKEND_PROJECT=cuda_backend"
+            set "MACROS=%MACROS% /p:Configuration=Release_CUDA"
+            set GENERATOR=.\generator_Release_CUDA.exe
+        )
+    )
 )
 
 

--- a/src/genn/backends/opencl/backend.cc
+++ b/src/genn/backends/opencl/backend.cc
@@ -2100,12 +2100,8 @@ void Backend::genMSBuildCompileModule(const std::string& moduleName, std::ostrea
     os << "\t\t<ClCompile Include=\"" << moduleName << ".cc\" />" << std::endl;
 }
 //--------------------------------------------------------------------------
-void Backend::genMSBuildImportTarget(std::ostream& os) const
+void Backend::genMSBuildImportTarget(std::ostream&) const
 {
-    os << "\t<ImportGroup Label=\"ExtensionTargets\">" << std::endl;
-    // Using targets provided by Intel
-    os << "\t\t<Import Project=\"$(OPENCL_PATH)\\BuildCustomizations\\IntelOpenCL.targets\" />" << std::endl;
-    os << "\t</ImportGroup>" << std::endl;
 }
 //--------------------------------------------------------------------------
 std::string Backend::getFloatAtomicAdd(const std::string& ftype, const char* memoryType) const


### PR DESCRIPTION
Just fixed a couple of minor things:
- Batch files don't have proper else if so you need to nest (this previously prevented -c working)
- The MSBuild project doesn't need to reference the Intel SDK, unlike with CUDA, it's just building standard C++ code